### PR TITLE
Modifications to make ADS run on recent scipy package versions and on non-UNIX operating system

### DIFF
--- a/codes/ADS_bin.py
+++ b/codes/ADS_bin.py
@@ -305,9 +305,9 @@ def get_stroke_seg_MNI(model, dwi_img, adc_img, Prob_IS=None, N_channel=3, DS=2)
     return stroke_pred_tmp
 
 def get_DirPaths():
-    CodesDir = os.path.dirname(os.path.abspath(__file__)) + '/'
+    CodesDir = os.path.dirname(os.path.abspath(__file__)) + os.path.sep
 #     print(CodesDir)
-    ProjectDir = os.path.join('/'.join(CodesDir.split('/')[0:-2]),'')
+    ProjectDir = os.path.join(os.path.sep.join(CodesDir.split(os.path.sep)[0:-2]),'')
     TemplateDir = os.path.join(ProjectDir,'data','template','')
     TrainedNetsDir = os.path.join(ProjectDir,'data','Trained_Nets','')
     return CodesDir, ProjectDir, TemplateDir, TrainedNetsDir
@@ -320,7 +320,7 @@ def gen_result_png(SubjDir,
 
     plt.rcParams["axes.grid"] = False
     
-    SubjID = os.path.join(SubjDir,'').split('/')[-2]
+    SubjID = os.path.join(SubjDir,'').split(os.path.sep)[-2]
     DwiPath = os.path.join(SubjDir, SubjID + '_DWI.nii')
     B0Path = os.path.join(SubjDir, SubjID + '_b0.nii')
     ADCPath = os.path.join(SubjDir, SubjID + '_ADC.nii')
@@ -700,7 +700,7 @@ def ADS(SubjDir,
         ):
     
     CodesDir, ProjectDir, TemplateDir, TrainedNetsDir = get_DirPaths()
-    SubjID = os.path.join(SubjDir,'').split('/')[-2]
+    SubjID = os.path.join(SubjDir,'').split(os.path.sep)[-2]
     MaskNet_name =  os.path.join(TrainedNetsDir, 'BrainMaskNet.h5')
     Lesion_model_name = os.path.join(TrainedNetsDir, model_name+'.h5')
     lesion_name = model_name + '_' + lesion_name

--- a/codes/ADS_bin.py
+++ b/codes/ADS_bin.py
@@ -210,7 +210,7 @@ def qfunc(x):
 def get_dwi_normalized(Dwi_ss_MNI_img,mask_raw_MNI_img):
     Dwi_d = Dwi_ss_MNI_img[mask_raw_MNI_img>0.5]
 
-    md = scipy.stats.mode(Dwi_d.astype('int16'))[0][0]
+    md = scipy.stats.mode(Dwi_d.astype('int16'), keepdims=True)[0][0]
     if md > np.mean(Dwi_d):
         p0_mu = md
     else:

--- a/codes/ADS_bin.py
+++ b/codes/ADS_bin.py
@@ -157,7 +157,7 @@ def check_regions(img):
 def remove_small_objects(img, remove_max_size=5, structure = np.ones((3,3))):
     binary = img
     binary[binary>0] = 1
-    labels = np.array(scipy.ndimage.label(binary, structure=structure))[0]
+    labels = scipy.ndimage.label(binary, structure=structure)[0]
     labels_num = [len(labels[labels==each]) for each in np.unique(labels)]
     new_img = img
     for index in np.unique(labels):

--- a/codes/ADS_bin.py
+++ b/codes/ADS_bin.py
@@ -62,7 +62,7 @@ with warnings.catch_warnings():
     warnings.simplefilter("ignore")
     warnings.warn("deprecated", DeprecationWarning)
 
-np.warnings.filterwarnings('ignore', category=np.VisibleDeprecationWarning)
+warnings.filterwarnings('ignore', category=np.VisibleDeprecationWarning)
     
 def get_new_NibImgJ(new_img, temp_imgJ, dataType=np.float32):
     temp_imgJ.set_data_dtype(dataType)

--- a/codes/ADS_bin.py
+++ b/codes/ADS_bin.py
@@ -187,7 +187,7 @@ def get_MaskNet_MNI(model, Dwi_MNI_img, B0_MNI_img):
     y_pred = (np.squeeze(y_pred)>0.5)*1.0
 
     dilate_mask = y_pred
-    mask_label, num_features = scipy.ndimage.measurements.label(dilate_mask)
+    mask_label, num_features = scipy.ndimage.label(dilate_mask)
     dilate_mask = (mask_label == mask_label[24,28,24])*1
     # for i in range(48):
     #     dilate_mask[:,:,i] = scipy.ndimage.binary_dilation(dilate_mask[:,:,i])*1.0

--- a/codes/ADS_bin.py
+++ b/codes/ADS_bin.py
@@ -51,7 +51,7 @@ from dipy.align import (affine_registration, center_of_mass, translation,
 from dipy.segment.mask import median_otsu
 from dipy.core.histeq import histeq
 
-from scipy.ndimage import morphology, gaussian_filter
+from scipy.ndimage import gaussian_filter
 from scipy.special import erf
 from scipy.optimize import minimize,leastsq, curve_fit
 
@@ -140,16 +140,16 @@ def Sequential_Registration_b0(static, static_grid2world, moving, moving_grid2wo
 
 def Stroke_closing(img):
     new_img = np.zeros_like(img)
-    new_img = morphology.binary_closing(img, structure=np.ones((2,2,2)))
+    new_img = scipy.ndimage.binary_closing(img, structure=np.ones((2,2,2)))
     return new_img
 
 def Stroke_connected(img, connect_radius=1):
-    return morphology.binary_dilation(img, morphology.ball(radius=connect_radius))
+    return scipy.ndimage.binary_dilation(img, scipy.ndimage.ball(radius=connect_radius))
 
 def check_regions(img):
     binary = np.zeros_like(img)
     binary[binary>0] = 1
-    labels = morphology.label(binary)
+    labels = scipy.ndimage.label(binary)
     labels_num = [len(labels[labels==each]) for each in np.unique(labels)]
     print(np.unique(labels))
     print(labels_num)
@@ -192,7 +192,7 @@ def get_MaskNet_MNI(model, Dwi_MNI_img, B0_MNI_img):
     # for i in range(48):
     #     dilate_mask[:,:,i] = scipy.ndimage.binary_dilation(dilate_mask[:,:,i])*1.0
     dilate_mask = Stroke_closing(dilate_mask)
-    dilate_mask = morphology.binary_fill_holes(dilate_mask)
+    dilate_mask = scipy.ndimage.binary_fill_holes(dilate_mask)
 
     upsampling_mask = np.repeat(np.repeat(np.repeat(dilate_mask, 4, axis=0), 4, axis=1), 4, axis=2)
 
@@ -300,7 +300,7 @@ def get_stroke_seg_MNI(model, dwi_img, adc_img, Prob_IS=None, N_channel=3, DS=2)
     stroke_pred_tmp = (stroke_pred_resampled>0.5)
 #     stroke_pred_tmp = remove_small_objects_InSlice(stroke_pred_tmp)
     stroke_pred_tmp = Stroke_closing(stroke_pred_tmp)
-    stroke_pred_tmp = morphology.binary_fill_holes(stroke_pred_tmp)
+    stroke_pred_tmp = scipy.ndimage.binary_fill_holes(stroke_pred_tmp)
     
     return stroke_pred_tmp
 
@@ -634,7 +634,7 @@ def ADS_pipeline(SubjDir,
     
     stroke_pred_raw_img = remove_small_objects_InSlice(stroke_pred_raw_img)
     stroke_pred_raw_img = Stroke_closing(stroke_pred_raw_img)
-    stroke_pred_raw_img = morphology.binary_fill_holes(stroke_pred_raw_img)
+    stroke_pred_raw_img = scipy.ndimage.binary_fill_holes(stroke_pred_raw_img)
     
     print('------ Inferencing lesion prediction ------')
     print('It takes %.2f seconds'% (time.time() - start_time))


### PR DESCRIPTION
Hi, I've made some simple modifications to the code to make ADS OS-agnostic (e.g. it should now run on windows) and to future-proof some parts which faced deprecation by newer scipy versions. I've taken care to ensure the compatibility of these changes with older versions of the packages too, so I think you can merge these changes without worrying about backward incompatibility.
I know that this is not the last version of ADS, and I've actually been working on ADS v.1.3 but there is no merging interface on NITRC, so hopefully this pull request gives you an idea of what changes to make on v.1.3. I'm also uploading the modified codes folder from ADS v1.3. This is versioned under git so you can pull these changes directly to your codebase if you wish.

[codes.zip](https://github.com/Chin-Fu-Liu/Acute-stroke_Detection_Segmentation/files/15008791/codes.zip)
